### PR TITLE
Release 1.0.0

### DIFF
--- a/.github/workflows/cleanup_failed_actions.yml
+++ b/.github/workflows/cleanup_failed_actions.yml
@@ -1,0 +1,35 @@
+name: Cleanup Failed Runs
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: write  # allow deleting workflow runs
+
+jobs:
+  cleanup_failed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete failed workflow runs
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            // Fetch up to 100 most recent completed runs
+            const response = await github.rest.actions.listWorkflowRunsForRepo({
+              owner,
+              repo,
+              status: 'completed',
+              per_page: 100
+            });
+            // Only keep runs that actually failed
+            const failedRuns = response.data.workflow_runs.filter(run => run.conclusion === 'failure');
+            if (failedRuns.length === 0) {
+              console.log('No failed workflow runs found.');
+            } else {
+              for (const run of failedRuns) {
+                console.log(`Deleting failed run id=${run.id}, name=${run.name}`);
+                await github.rest.actions.deleteWorkflowRun({ owner, repo, run_id: run.id });
+              }
+            }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# UsefulGithubCICD
+
+A collection of helpful GitHub Actions workflows designed to streamline continuous integration and deployment (CI/CD) for your repositories.
+
+## Features
+
+- **Cleanup Failed Runs** (`cleanup_failed_actions.yml`): Automatically delete failed workflow runs to keep your Actions history clean.
+- (Coming soon) More workflows to manage releases, dependencies, security scans, and more.
+
+## Installation
+
+Simply copy the workflow file(s) you need into your repository’s `.github/workflows/` directory:
+
+```bash
+cp path/to/UsefulGithubCICD/.github/workflows/<workflow-file>.yml .github/workflows/
+``` 
+
+Alternatively, reference a workflow directly from this repository:
+
+```yaml
+# .github/workflows/cleanup_failed_actions.yml
+name: Cleanup Failed Runs
+on:
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    uses: <YOUR_GITHUB_USERNAME>/UsefulGithubCICD/.github/workflows/cleanup_failed_actions.yml@main
+    with:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Usage
+
+1. Add or reference the workflow in your project.
+2. Provide any required inputs or permissions as documented in each workflow file.
+3. Trigger the workflow manually or on your preferred GitHub events.
+
+## Available Workflows
+
+| File                             | Description                                     |
+|----------------------------------|-------------------------------------------------| 
+| `cleanup_failed_actions.yml`     | Deletes all failed workflow runs on-demand.     |
+
+*(Contributions to expand this list are welcome!)*
+
+## Contributing
+
+Contributions are highly appreciated:
+
+1. Fork this repository.
+2. Create a new branch for your feature or fix.
+3. Add or update workflow YAML files under `.github/workflows/`.
+4. Test your changes.
+5. Submit a pull request detailing your improvements.
+
+Please follow standard [GitHub Flow](https://guides.github.com/introduction/flow/) and adhere to best practices for Actions workflows.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).
+
+## Contact
+
+Maintained by [Your Name] — feel free to open issues or pull requests with questions or suggestions.


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to clean up failed runs and updates the repository's `README.md` to document this workflow and provide guidance on usage and contributions.

### New GitHub Actions Workflow:
* Added `cleanup_failed_actions.yml` to `.github/workflows/` to automate the deletion of failed workflow runs. This workflow uses the `actions/github-script` action to identify and delete up to 100 failed runs in the repository. It is triggered manually using `workflow_dispatch`.

### Documentation Updates:
* Updated `README.md` to include details about the repository's purpose, features, and usage instructions for the `Cleanup Failed Runs` workflow. The documentation also outlines steps for contributing to the repository and includes a license section.