### PR TITLE
Release 1.0.4

### DIFF
--- a/.github/workflows/cleanup_all_actions.yml
+++ b/.github/workflows/cleanup_all_actions.yml
@@ -16,7 +16,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
-            // Fetch up to 1000 most recent completed runs
+            const currentRunId = process.env.GITHUB_RUN_ID;
             let page = 1;
             let deleted = 0;
             while (true) {
@@ -29,6 +29,10 @@ jobs:
               const runs = response.data.workflow_runs;
               if (runs.length === 0) break;
               for (const run of runs) {
+                if (String(run.id) === String(currentRunId)) {
+                  console.log(`Skipping current run id=${run.id}`);
+                  continue;
+                }
                 console.log(`Deleting run id=${run.id}, name=${run.name}, status=${run.status}, conclusion=${run.conclusion}`);
                 await github.rest.actions.deleteWorkflowRun({ owner, repo, run_id: run.id });
                 deleted++;
@@ -36,7 +40,7 @@ jobs:
               page++;
             }
             if (deleted === 0) {
-              console.log('No workflow runs found to delete.');
+              console.log('No workflow runs found to delete (except current run).');
             } else {
-              console.log(`Deleted ${deleted} workflow runs.`);
+              console.log(`Deleted ${deleted} workflow runs (except current run).`);
             }


### PR DESCRIPTION
This pull request updates the `.github/workflows/cleanup_all_actions.yml` workflow to ensure the current workflow run is not accidentally deleted during cleanup. The changes add logic to identify and skip the current run while deleting other completed runs.

Key changes:

### Workflow behavior improvements:
* Introduced a new variable, `currentRunId`, to store the ID of the current workflow run using `process.env.GITHUB_RUN_ID`. This ensures the script can identify the current run.
* Added a condition to skip the current workflow run during the deletion loop, logging a message when it is skipped.
* Updated log messages to clarify that the current workflow run is excluded from the deletion count.